### PR TITLE
[FIX] Download Links:Most Recent Version, Remove Redundant code

### DIFF
--- a/mode/src/processing/mode/android/AndroidEditor.java
+++ b/mode/src/processing/mode/android/AndroidEditor.java
@@ -183,6 +183,22 @@ public class AndroidEditor extends JavaEditor {
     });
     androidMenu.add(item);
 
+    //For testing SDK Downloader - Remove Later. --------------------------------------
+    item = new JMenuItem("SDK Downloader");
+    item.addActionListener(new ActionListener() {
+      public void actionPerformed(ActionEvent e) {
+        try {
+          AndroidSDK.download(null,androidMode);
+        } catch (AndroidSDK.BadSDKException ex) {
+          ex.printStackTrace();
+        } catch (AndroidSDK.CancelException ex) {
+          ex.printStackTrace();
+        }
+      }
+    });
+    androidMenu.add(item);
+    //--------------------------------------------------------------------
+
     androidMenu.addSeparator();
      
     fragmentItem = new JCheckBoxMenuItem(AndroidMode.getTextString("menu.android.app"));


### PR DESCRIPTION
# What:
- This enables the SDK downloader to download the recent Platform, PlatformTool, BuildTool, Emulator, and Tools. 
- This removes redundant code by converting them into methods.
- Contains testing code involved for running the sdk downloader.

# Why:
- We have been downloading static SDK platform 26.
- Always picking the first appearing package from the repository, which might not be the recent one.
- Lots of repeating lines of code , which could be shortened .

# How:
- Changes made to ```getMainDownloadUrls``` method of ```SDKDownloader``` class.
- New method to parse and return the most recent version, ```getRecentVersion()``` was added.
- The version extracted is then added to the ```UrlHolder```.
- New method to remove redundant code for parsing the download link, ```parseURL()``` was added.

# Test:
- A menu item has been created for testing purposes: Android -> SDK Downloader.
- The versions being downloaded, will be printed out to the console. 
- Note: Delete the android folder in the sketchbookfolder (.sketchbook - linux, documents/processing - windows).