### PR TITLE
 [FEAT] SDK Updater, Individual package updates,ProgressBar

### DIFF
--- a/mode/tools/SDKUpdater/src/processing/mode/android/tools/SDKUpdater.java
+++ b/mode/tools/SDKUpdater/src/processing/mode/android/tools/SDKUpdater.java
@@ -262,6 +262,7 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
         }
       }
 
+      Collections.sort(platformList,comparator);
       return null;
     }
 
@@ -300,6 +301,17 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
       }
       return false;
     }
+
+    Comparator<Vector> comparator = new Comparator<Vector>() {
+      @Override
+      public int compare(Vector o1, Vector o2) {
+        String name1 = (String) o1.get(1);
+        String name2 = (String) o2.get(1);
+        int version1 = Integer.parseInt(name1.substring(name1.indexOf(" ")+1));
+        int version2 = Integer.parseInt(name2.substring(name2.indexOf(" ")+1));
+        return version2 - version1;
+      }
+    };
   }
 
   class DownloadTask extends SwingWorker<Object, Object> {

--- a/mode/tools/SDKUpdater/src/processing/mode/android/tools/SDKUpdater.java
+++ b/mode/tools/SDKUpdater/src/processing/mode/android/tools/SDKUpdater.java
@@ -483,7 +483,8 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
     packageTable = new DefaultTableModel(NUM_ROWS, columns_tools.size()) {
       @Override
       public boolean isCellEditable(int row, int column) {
-        if (column == 0) return true;
+        String version = (String) packageTable.getValueAt(row,3);
+        if (!version.equals("")) return true; //only if update exists
         return false;
       }
 
@@ -606,7 +607,8 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
     platformTable = new DefaultTableModel(NUM_ROWS, columns_platforms.size()) {
       @Override
       public boolean isCellEditable(int row, int column) {
-        if (column == 0) return true;
+        String status = (String) platformTable.getValueAt(row,3);
+        if(status.equals("Not Installed")) return true;
         return false;
       }
 

--- a/mode/tools/SDKUpdater/src/processing/mode/android/tools/SDKUpdater.java
+++ b/mode/tools/SDKUpdater/src/processing/mode/android/tools/SDKUpdater.java
@@ -32,6 +32,7 @@ import com.android.sdklib.repository.legacy.LegacyDownloader;
 import com.android.sdklib.tool.sdkmanager.SdkManagerCli;
 
 import processing.app.Base;
+import processing.app.Messages;
 import processing.app.Preferences;
 import processing.app.tools.Tool;
 import processing.app.ui.Toolkit;
@@ -325,6 +326,12 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
           throw new SdkManagerCli.CommandFailedException();
         }
         remotes.add(p);
+      }
+
+      if (remotes.size() == 0) {
+        actionButtonPlatform.setText("Install");
+        Messages.showWarning("SDK Updater","No platform was selected");
+        return null;
       }
 
       remotes = InstallerUtil.computeRequiredPackages(

--- a/mode/tools/SDKUpdater/src/processing/mode/android/tools/SDKUpdater.java
+++ b/mode/tools/SDKUpdater/src/processing/mode/android/tools/SDKUpdater.java
@@ -92,6 +92,7 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
   private JButton actionButtonPlatform;
   private JTable table;
   private JTable tablePlatforms;
+  private JTabbedPane tabs;
 
   private ArrayList<String> packagePathsList;
   private ArrayList<String> platformPathsList;
@@ -245,18 +246,20 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
       for (String path: installed.keySet()) {
         Vector info = new Vector();
         List locInfo = installed.get(path);
-        packagePathsList.add(path);
-        info.add(false);
-        info.add(locInfo.get(0));
-        info.add(locInfo.get(1));
-        if (updated.containsKey(path)) {
-          String upVer = updated.get(path).get(1);
-          info.add(upVer);
-          numUpdates++;
-        } else {
-          info.add("");
+        if (!isPlatform(path)) {
+          packagePathsList.add(path);
+          info.add(false);
+          info.add(locInfo.get(0));
+          info.add(locInfo.get(1));
+          if (updated.containsKey(path)) {
+            String upVer = updated.get(path).get(1);
+            info.add(upVer);
+            numUpdates++;
+          } else {
+            info.add("");
+          }
+          packageList.add(info);
         }
-        packageList.add(info);
       }
 
       return null;
@@ -287,6 +290,15 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
             e.getCause().toString(), "Error", JOptionPane.ERROR_MESSAGE);
         e.printStackTrace();
       }
+    }
+
+    private Boolean isPlatform(String path){
+      int end_pos = path.indexOf(";");
+      String pathType = end_pos != -1 ? path.substring(0,end_pos) : "" ;
+      if (pathType.equals("platforms")) {
+        return true;
+      }
+      return false;
     }
   }
 
@@ -330,6 +342,7 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
 
       if (remotes.size() == 0) {
         actionButtonPlatform.setText("Install");
+        actionButton.setText("Update");
         Messages.showWarning("SDK Updater","No platform was selected");
         return null;
       }
@@ -360,6 +373,7 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
       try {
         get();
         actionButton.setEnabled(false);
+        tabs.setEnabled(true);
         status.setText("Refreshing packages...");
         statusPlatform.setText("Refreshing packages...");
         queryTask = new QueryTask();
@@ -432,7 +446,7 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
     Box verticalBox1 = Box.createVerticalBox();
     verticalBox1.setBorder(new EmptyBorder(BORDER, BORDER, BORDER, BORDER));
 
-    JTabbedPane tabs = new JTabbedPane();
+    tabs = new JTabbedPane();
     tabs.add("SDK Tools",verticalBox);
     tabs.add("Platforms",verticalBox1);
     outer.add(tabs);
@@ -523,6 +537,7 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
 
           status.setText("Downloading available updates...");
           actionButton.setText("Cancel");
+          tabs.setEnabled(false);
         }
       }
     });
@@ -628,6 +643,7 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
           progressBarPlatform.setIndeterminate(true);
           downloadTask.execute();
           actionButtonPlatform.setText("Cancel");
+          tabs.setEnabled(false);
         }
       }
     });

--- a/mode/tools/SDKUpdater/src/processing/mode/android/tools/SDKUpdater.java
+++ b/mode/tools/SDKUpdater/src/processing/mode/android/tools/SDKUpdater.java
@@ -67,7 +67,7 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
   
   private final Vector<String> columns_tools = new Vector<>(Arrays.asList("Select",
       "Package name", "Installed version", "Available update"));
-  private final Vector<String> columns_platforms = new Vector<>(Arrays.asList("Platform",
+  private final Vector<String> columns_platforms = new Vector<>(Arrays.asList("Select","Platform",
           "Revision","Status"));
   private static final String PROPERTY_CHANGE_QUERY = "query";
 

--- a/mode/tools/SDKUpdater/src/processing/mode/android/tools/SDKUpdater.java
+++ b/mode/tools/SDKUpdater/src/processing/mode/android/tools/SDKUpdater.java
@@ -771,9 +771,12 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
       JOptionPane.showMessageDialog(null,
           "Download canceled", "Warning", JOptionPane.WARNING_MESSAGE);
 
-      //reset progress bar
-      progressBar.setValue(0);
-      progressBarPlatform.setValue(0);
+      //re-query:
+      actionButton.setText("Refreshing packages. . . ");
+      actionButtonPlatform.setText("Refreshing packages. . . ");
+      queryTask = new QueryTask();
+      queryTask.addPropertyChangeListener(SDKUpdater.this);
+      queryTask.execute();
     }
   }
   

--- a/mode/tools/SDKUpdater/src/processing/mode/android/tools/SDKUpdater.java
+++ b/mode/tools/SDKUpdater/src/processing/mode/android/tools/SDKUpdater.java
@@ -772,8 +772,8 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
           "Download canceled", "Warning", JOptionPane.WARNING_MESSAGE);
 
       //re-query:
-      actionButton.setText("Refreshing packages. . . ");
-      actionButtonPlatform.setText("Refreshing packages. . . ");
+      status.setText("Refreshing packages. . . ");
+      statusPlatform.setText("Refreshing packages. . . ");
       queryTask = new QueryTask();
       queryTask.addPropertyChangeListener(SDKUpdater.this);
       queryTask.execute();

--- a/mode/tools/SDKUpdater/src/processing/mode/android/tools/SDKUpdater.java
+++ b/mode/tools/SDKUpdater/src/processing/mode/android/tools/SDKUpdater.java
@@ -262,7 +262,8 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
         }
       }
 
-      Collections.sort(platformList,comparator);
+      Collections.sort(platformList,comparePlatformInfo);
+      Collections.sort(platformPathsList,comparePlatformPath);
       return null;
     }
 
@@ -302,13 +303,22 @@ public class SDKUpdater extends JFrame implements PropertyChangeListener, Tool {
       return false;
     }
 
-    Comparator<Vector> comparator = new Comparator<Vector>() {
+    Comparator<Vector> comparePlatformInfo = new Comparator<Vector>() {
       @Override
       public int compare(Vector o1, Vector o2) {
         String name1 = (String) o1.get(1);
         String name2 = (String) o2.get(1);
         int version1 = Integer.parseInt(name1.substring(name1.indexOf(" ")+1));
         int version2 = Integer.parseInt(name2.substring(name2.indexOf(" ")+1));
+        return version2 - version1;
+      }
+    };
+
+    Comparator<String> comparePlatformPath = new Comparator<String>() {
+      @Override
+      public int compare(String o1, String o2) {
+        int version1 = Integer.parseInt(o1.substring(o1.indexOf("-")+1));
+        int version2 = Integer.parseInt(o2.substring(o2.indexOf("-")+1));
         return version2 - version1;
       }
     };


### PR DESCRIPTION
# What:
- Android SDK Updater with two different tabs for platform tools and platforms.
- Add checkboxes for user selection and installation of individual packets.

# Why:
- As we allow users to have recent versions, updating them and also testing sketches on older versions is important. 

# How:
- Modified DownloadTask Swing worker of SDKUpdater class.
- Modified the createLayout method to support tabbed pane.
- Modified table model to add check boxes. 

# Issues :
- The platform is not displayed in order, needs to be sorted. #11  [fixed]
- Prevent switching of tabs, when either platform or platform tools is being downloaded. #10 [fixed]
- Progress Bar : [https://github.com/processing/processing-android/issues/362](url)

# Test : 
- Open PDE, Android -> SDK Updater
